### PR TITLE
Add operation annotation to x-ray segments

### DIFF
--- a/tracing/xray/xray.go
+++ b/tracing/xray/xray.go
@@ -25,6 +25,12 @@ func (t *Tracer) OnSpanStart(ctx *spcontext.Context, name, resource string) *spc
 	}
 
 	newCtx, segment := createFn(ctx, name)
+	if name != "" {
+		if err := segment.AddAnnotation("operation", name); err != nil {
+			_ = ctx.DirectError(err, "failed to add operation annotation to an X-Ray segment")
+		}
+	}
+
 	if resource != "" {
 		if err := segment.AddAnnotation("resource", resource); err != nil {
 			_ = ctx.DirectError(err, "failed to add resource annotation to an X-Ray segment")


### PR DESCRIPTION
It looks like you can't search by subsegment name in the xray console, so I'm adding an `operation` annotation to make searching possible.