### PR TITLE
Hook into starting spans

### DIFF
--- a/context.go
+++ b/context.go
@@ -59,7 +59,7 @@ func WithTracer(tracer Tracer) ContextOption {
 }
 
 // OnSpanStart adds an on span start hook to the new context.
-func OnSpanStart(hook func(Span, Span)) ContextOption {
+func OnSpanStart(hook func(parentSpan, activeSpan Span)) ContextOption {
 	return func(ctx *Context) {
 		ctx.onSpanStartHooks = append(ctx.onSpanStartHooks, hook)
 	}

--- a/middleware.go
+++ b/middleware.go
@@ -14,11 +14,12 @@ import (
 func ContextInjector(ctx *Context) func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	return func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 		next(w, r.WithContext(&Context{
-			Context:  &mergeValuesContext{base: r.Context(), merged: ctx.Context},
-			fields:   ctx.fields,
-			logger:   ctx.logger,
-			Notifier: ctx.Notifier,
-			Tracer:   ctx.Tracer,
+			Context:          &mergeValuesContext{base: r.Context(), merged: ctx.Context},
+			fields:           ctx.fields,
+			logger:           ctx.logger,
+			Notifier:         ctx.Notifier,
+			Tracer:           ctx.Tracer,
+			onSpanStartHooks: ctx.onSpanStartHooks,
 		}))
 	}
 }
@@ -28,11 +29,12 @@ func ContextInjector(ctx *Context) func(w http.ResponseWriter, r *http.Request, 
 func GRPCStreamContextInjector(ctx *Context) grpc.StreamServerInterceptor {
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		newCtx := &Context{
-			Context:  &mergeValuesContext{base: stream.Context(), merged: ctx.Context},
-			fields:   ctx.fields,
-			logger:   ctx.logger,
-			Notifier: ctx.Notifier,
-			Tracer:   ctx.Tracer,
+			Context:          &mergeValuesContext{base: stream.Context(), merged: ctx.Context},
+			fields:           ctx.fields,
+			logger:           ctx.logger,
+			Notifier:         ctx.Notifier,
+			Tracer:           ctx.Tracer,
+			onSpanStartHooks: ctx.onSpanStartHooks,
 		}
 		wrappedStream := grpc_middleware.WrapServerStream(stream)
 		wrappedStream.WrappedContext = newCtx


### PR DESCRIPTION
The purpose of this modification is to enable the ability to connect to the initiation of spans. 

I am adding the active span to the context to utilize it as the parent span in the future. 

Both spans are transferred to the hook.