### PR TITLE
feat(bugsnug): pass error class to bugsnag explicitly

### DIFF
--- a/context.go
+++ b/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -333,12 +334,14 @@ func (ctx *Context) error(fields []interface{}, err error, internal InternalMess
 	if ctx.Notifier != nil && !strings.Contains(err.Error(), context.Canceled.Error()) {
 		var parentErr = err
 		var st stackTracer
+		var errorClass string
 		curSt, ok := parentErr.(stackTracer)
 		if ok {
 			st = curSt
 		}
 
 		var curErr = err
+		errorClass = reflect.TypeOf(err).String()
 		for {
 			unwrapped := errors.Unwrap(curErr)
 			if unwrapped == nil {
@@ -353,13 +356,15 @@ func (ctx *Context) error(fields []interface{}, err error, internal InternalMess
 		}
 		if st != nil {
 			curErr = &errorWithStackFrames{err: st}
+			errorClass = reflect.TypeOf(st).String()
 		} else {
 			curErr = parentErr
+			errorClass = reflect.TypeOf(parentErr).String()
 		}
 
 		fieldsMap["original_error"] = parentErr.Error()
 
-		if err := ctx.Notifier.Notify(curErr, bugsnag.MetaData{FieldsTab: fieldsMap}, ctx); err != nil {
+		if err := ctx.Notifier.Notify(curErr, bugsnag.MetaData{FieldsTab: fieldsMap}, ctx, bugsnag.ErrorClass{Name: errorClass}); err != nil {
 			ctx.Errorf("error notifying the exception tracker: %v", err)
 		}
 	}

--- a/context.go
+++ b/context.go
@@ -341,7 +341,6 @@ func (ctx *Context) error(fields []interface{}, err error, internal InternalMess
 		}
 
 		var curErr = err
-		errorClass = reflect.TypeOf(err).String()
 		for {
 			unwrapped := errors.Unwrap(curErr)
 			if unwrapped == nil {


### PR DESCRIPTION
related to: https://app.clickup.com/t/8695ccuv1

## Before the PR

![Screenshot 2024-08-12 at 15 01 16](https://github.com/user-attachments/assets/77a145c8-f45b-48b0-b1cf-7dfc2eb52c36)

All errors have an error class of our own custom error that we create for all errors.

## After the PR

![Screenshot 2024-08-12 at 15 02 05](https://github.com/user-attachments/assets/9e8810d8-9184-458a-986c-fa3b242edf3d)

When creating our custom error, this will extract the original error type and pass it to bugsnag explicitly.

The PR works as expected, but there's a significant portion of errors in our codebase which are created inline with `errors.New()` so we are replacing one generic error type with another. More improvement will be possible by reporting the path correctly.

This PR is still an improvement in a few ways. We are closer to the actual error type. Also, not all errors use `errors.New()`, so in those cases we will now have proper error class reported.

## Is there anything else about the error class that we can improve?

### After the PR, pkg level error based on `errors.New()`

```go
var ErrNotAGlobalUnicast = errors.New("not a global unicast address")
```

![Screenshot 2024-08-12 at 15 04 47](https://github.com/user-attachments/assets/e17364f8-05ee-4ac3-af5a-22958b5ff4ad)

We get the same error type as before, the path is different because it's using the line were the error is introduced, I think this is actually worse because we don't know where the error was returned and we also lose the entire stack trace.

### After the PR, custom error type

```go
type ErrNotAGlobalUnicast struct{}

func (e *ErrNotAGlobalUnicast) Error() string {
	return "not a global unicast address"
}
```

![Screenshot 2024-08-12 at 15 09 52](https://github.com/user-attachments/assets/24a9d171-b017-45bb-930a-46ddf39f0ec4)

Custom struct implementing the Error interface, it actually prints out messages from all the errors wrapping the original error and the entire stack trace. It's actually not the error type that I created, but instead an error one level down in the call stack. In the previous func we wrap the returned error with `errors.Wrap()`: https://github.com/spacelift-io/backend/blob/00a9a26271c954cad538bb8887403fe09ba6ece8/shared/vcs/github_integration.go#L1057

What happened here is that our "wrapper" traversed up to the last stack that has a stacktrace (`errors.Wrap()` error has a `StackTrace()` method, the new one does not) and then returned it's type and stack trace.

If we wanted our current logic to capture the new error type, it would have to implement the `StackTrace()` method.
