### PR TITLE
fix: loosing notified error type

### DIFF
--- a/context.go
+++ b/context.go
@@ -323,7 +323,7 @@ func (ctx *Context) error(fields []interface{}, err error, internal InternalMess
 	}
 	if notifiedErr := (notifiedError{}); errors.As(err, &notifiedErr) {
 		// This error has already been notified to bugsnag before.
-		return safe
+		return notifiedError{error: safe}
 	}
 
 	fieldsMap := make(map[string]interface{})

--- a/context_test.go
+++ b/context_test.go
@@ -328,5 +328,5 @@ func TestNotifiedLogic(t *testing.T) {
 	base.Notifier = notifier
 	err := base.InternalError(errors.New("initial error"), "foo")
 	err = base.DirectError(err, "skipped error")
-	err = base.DirectError(err, "also skipped error")
+	_ = base.DirectError(err, "also skipped error")
 }


### PR DESCRIPTION
When we call `spcontext.error` twice, the second call actually unwraps it and removes the notified error wrapper.

It means that the third call will again notify Bugsnag because the type is the type of underlying notified error.