### PR TITLE
Add `operation.name` to OTEL attributes

### DIFF
--- a/tracing/opentelemetry/opentelemetry.go
+++ b/tracing/opentelemetry/opentelemetry.go
@@ -21,6 +21,9 @@ func (t *Tracer) OnSpanStart(ctx *spcontext.Context, name, resource string) *spc
 	if resource != "" {
 		opts = append(opts, trace.WithAttributes(attribute.String("resource", resource)))
 	}
+	if name != "" {
+		opts = append(opts, trace.WithAttributes(attribute.String("operation.name", name)))
+	}
 
 	parentContext := ctx
 


### PR DESCRIPTION
As per their new documentation: https://docs.datadoghq.com/opentelemetry/migrate/migrate_operation_names/?tab=opentelemetrycollector

<img width="762" alt="image" src="https://github.com/user-attachments/assets/68cef5b5-a11b-4d2d-a751-f93ff7d1a77b" />
