### PR TITLE
feat: report wrapped error to span

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -149,7 +149,7 @@ func (s *span) Close(err error, opts ...SpanCloseOption) {
 	// error that we report to our observability.
 	var notifiedErr notifiedError
 	if errors.As(err, &notifiedErr) {
-		err = notifiedErr.internal
+		err = notifiedErr.err
 	}
 
 	s.ctx.Tracer.OnSpanClose(s.ctx, err, fields, s.drop || cfg.Drop, s.analyze || cfg.Analyze)


### PR DESCRIPTION
The `RawError()` method wraps an error with a supplied message before reporting it. I'm adjusting the code so that we'll report the wrapped error instead of the raw error to make it easier to trace back to the code from traces / bugsnag.

I've also renamed the `internal` field in `notifiedError` to `err` so that it's less confusing since we already have an `internal` parameter being passed to the `error()` method that is something different.