### PR TITLE
fix: include internal message in traced error

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -149,7 +149,7 @@ func (s *span) Close(err error, opts ...SpanCloseOption) {
 	// error that we report to our observability.
 	var notifiedErr notifiedError
 	if errors.As(err, &notifiedErr) {
-		err = notifiedErr.err
+		err = notifiedErr.internal
 	}
 
 	s.ctx.Tracer.OnSpanClose(s.ctx, err, fields, s.drop || cfg.Drop, s.analyze || cfg.Analyze)


### PR DESCRIPTION
In my previous PR I had altered `RawError` to pass in the wrapped error, but that caused some issues in existing usages where we would end up with odd duplicate error messages being reported.

I've taken a slightly different approach this time of altering `RawError` to pass through the message rather than the wrapped error as the `internal` parameter, which then gets wrapped again inside `error`. It's a little odd, but it means that we can include the message in the trace, but avoid logging out duplicate information in the error log.