### PR TITLE
fix: respect Notify() bool on original error before unwrapping to stackTracer

### DIFF
--- a/context.go
+++ b/context.go
@@ -371,6 +371,27 @@ func (e notifiedError) Unwrap() error {
 	return e.internal
 }
 
+// NotifyError is an optional interface error types can implement to control
+// whether the error (or any error wrapping one) is sent to the configured
+// Notifier. Returning false suppresses the notifier call while still logging.
+// The decision is taken from the outermost implementor found in the chain via
+// errors.As.
+type NotifyError interface {
+	Notify() bool
+}
+
+// shouldNotify inspects the original error chain for a NotifyError implementor
+// and respects its decision. This must run before the chain is unwrapped to
+// find a stackTracer, since that unwrap replaces the error with a bare wrapper
+// that no longer exposes the NotifyError interface to downstream notifiers.
+func shouldNotify(err error) bool {
+	var ne NotifyError
+	if errors.As(err, &ne) {
+		return ne.Notify()
+	}
+	return true
+}
+
 func (ctx *Context) error(fields []interface{}, err error, internal InternalMessage, safe SafeMessage) error {
 	if err == nil {
 		return nil
@@ -387,7 +408,7 @@ func (ctx *Context) error(fields []interface{}, err error, internal InternalMess
 		fieldsMap[fields[2*i].(string)] = fields[2*i+1]
 	}
 
-	if ctx.Notifier != nil && !strings.Contains(err.Error(), context.Canceled.Error()) {
+	if ctx.Notifier != nil && !strings.Contains(err.Error(), context.Canceled.Error()) && shouldNotify(err) {
 		var parentErr = err
 		var st stackTracer
 		var errorClass string

--- a/context_test.go
+++ b/context_test.go
@@ -331,6 +331,79 @@ func TestNotifiedLogic(t *testing.T) {
 	_ = base.DirectError(err, "also skipped error")
 }
 
+type suppressNotifyError struct{ error }
+
+func (e suppressNotifyError) Notify() bool  { return false }
+func (e suppressNotifyError) Unwrap() error { return e.error }
+
+type allowNotifyError struct{ error }
+
+func (e allowNotifyError) Notify() bool  { return true }
+func (e allowNotifyError) Unwrap() error { return e.error }
+
+func TestNotifyInterface(t *testing.T) {
+	t.Run("suppresses notifier when error implements Notify() bool = false", func(t *testing.T) {
+		logBuffer := bytes.NewBuffer(nil)
+		notifier := new(testutils.MockNotifier)
+		defer notifier.AssertExpectations(t)
+
+		ctx := spcontext.New(log.NewLogfmtLogger(logBuffer))
+		ctx.Notifier = notifier
+
+		err := suppressNotifyError{error: errors.New("boom")}
+		returned := ctx.InternalError(err, "op failed")
+
+		assert.EqualError(t, returned, "internal error")
+		assert.Contains(t, logBuffer.String(), `level=error msg="op failed: boom"`)
+		notifier.AssertNotCalled(t, "Notify")
+	})
+
+	t.Run("suppresses notifier when Notify() bool = false is wrapped", func(t *testing.T) {
+		logBuffer := bytes.NewBuffer(nil)
+		notifier := new(testutils.MockNotifier)
+		defer notifier.AssertExpectations(t)
+
+		ctx := spcontext.New(log.NewLogfmtLogger(logBuffer))
+		ctx.Notifier = notifier
+
+		// Mirror the Bugsnag error chain from the production incident:
+		// errors.Wrap(UserError{errors.Wrap(fundamental, ...)}, ...).
+		inner := errors.New("fundamental")
+		userErr := suppressNotifyError{error: errors.Wrap(inner, "user-facing")}
+		outer := errors.Wrap(userErr, "outer")
+
+		returned := ctx.InternalError(outer, "op failed")
+
+		assert.EqualError(t, returned, "internal error")
+		notifier.AssertNotCalled(t, "Notify")
+	})
+
+	t.Run("calls notifier when error implements Notify() bool = true", func(t *testing.T) {
+		logBuffer := bytes.NewBuffer(nil)
+		notifier := new(testutils.MockNotifier)
+		notifier.On("Notify", mock.Anything, mock.Anything).Return(nil).Once()
+		defer notifier.AssertExpectations(t)
+
+		ctx := spcontext.New(log.NewLogfmtLogger(logBuffer))
+		ctx.Notifier = notifier
+
+		err := allowNotifyError{error: errors.New("boom")}
+		_ = ctx.InternalError(err, "op failed")
+	})
+
+	t.Run("calls notifier when chain has no Notify() implementor", func(t *testing.T) {
+		logBuffer := bytes.NewBuffer(nil)
+		notifier := new(testutils.MockNotifier)
+		notifier.On("Notify", mock.Anything, mock.Anything).Return(nil).Once()
+		defer notifier.AssertExpectations(t)
+
+		ctx := spcontext.New(log.NewLogfmtLogger(logBuffer))
+		ctx.Notifier = notifier
+
+		_ = ctx.InternalError(errors.New("boom"), "op failed")
+	})
+}
+
 func TestLogLevel(t *testing.T) {
 	testCases := []struct {
 		name        string


### PR DESCRIPTION
It looks like [Notify() = false](https://github.com/spacelift-io/backend/blob/860da4796f41c312c42ce7c78dda45708d7ce0c4/observability/notifier/bugsnag_notifier.go#L69) is not working as intended. It was meant to suppress errors from being sent to Bugsnag, but I've come across a [UserError](https://github.com/spacelift-io/backend/blob/860da4796f41c312c42ce7c78dda45708d7ce0c4/decentralized/comms/client.go#L420), which has `Notify() = false` by default`, being sent anyway (see [bugsnag](https://app.bugsnag.com/spacelift/workers-prod/errors/69d703d26bb8e831663d7504?filters%5Berror.status%5D=open&filters%5Bevent.since%5D=30d))

## What

`Context.error` unwraps the error chain to find the deepest `stackTracer` and wraps it in `&errorWithStackFrames{err: stackTracer}` before handing it to `ctx.Notifier.Notify`. That wrapper has no reference to the original chain, so any `Notify() bool` implementor above the deepest `stackTracer` (e.g. `UserError`, `WithoutNotifyError`) is silently stripped before the downstream `BugsnagWrapper` can honor it.

This PR:

1. Exports a new `NotifyError` interface (`Notify() bool`) so callers can opt errors out of notifications.
2. Adds a `shouldNotify(err)` guard in `Context.error` that inspects the **original** `err` for `NotifyError` **before** the stripping loop runs, skipping the notifier when `Notify()` returns `false`.
3. Adds regression tests covering the exact production chain

`errorWithStackFrames` is intentionally left unchanged to avoid altering Bugsnag error grouping.

## A bit of history

`Notify() bool` was introduced in backend PR `25d36cc8f` (#12116) to let `UserError` suppress Bugsnag notifications. It was unit-tested against `BugsnagWrapper.Notify` directly and appeared to work — but every real call site routes errors through `ctx.RawError` → `Context.error` → `BugsnagWrapper.Notify`. The stripping made `Notify() bool` to not work in production for ~5 months if I'm right.

## Test plan

- [x] `go test -count=1 ./...` — all suites pass.
- [x] Regression confirmed: disabling `shouldNotify(err)` makes the new tests fail on unexpected mock invocations; with the guard, they pass.