### PR TITLE
fix(bugsnag): skip init-only stacks when walking the error chain

### DIFF
--- a/bugsnag.go
+++ b/bugsnag.go
@@ -38,6 +38,49 @@ func (e *errorWithStackFrames) Error() string {
 	return e.err.Error()
 }
 
+// hasInitTimeStackOnly reports whether st's stack contains only frames from
+// process startup (runtime.*, main.main, package init functions).
+//
+// This is the signature of a pkg/errors error created at package init via
+// `var ErrFoo = errors.New("...")` or similar, whose captured stack points to nothing
+// meaningful.
+//
+// The chain walk in (*Context).error skips such stacks so Bugsnag receives a useful
+// frame instead.
+func hasInitTimeStackOnly(st stackTracer) bool {
+	trace := st.StackTrace()
+	if len(trace) == 0 {
+		return false
+	}
+	for _, frame := range trace {
+		pc := uintptr(frame) - 1
+		fn := runtime.FuncForPC(pc)
+		if fn == nil {
+			return false
+		}
+		if !isInitOrRuntimeFrame(fn.Name()) {
+			return false
+		}
+	}
+	return true
+}
+
+// isInitOrRuntimeFrame matches function names produced by the Go runtime's
+// startup sequence and compiler-generated package init functions.
+func isInitOrRuntimeFrame(name string) bool {
+	switch {
+	case strings.HasPrefix(name, "runtime."):
+		return true
+	case name == "main.main":
+		return true
+	case strings.HasSuffix(name, ".init"):
+		return true
+	case strings.Contains(name, ".init."):
+		return true
+	}
+	return false
+}
+
 func (e *errorWithStackFrames) StackFrames() []bugsnagerrors.StackFrame {
 	stackTrace := e.err.StackTrace()
 

--- a/bugsnag_test.go
+++ b/bugsnag_test.go
@@ -1,0 +1,63 @@
+package spcontext
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// initSentinelErr is created at package init, just like real production
+// sentinels; its stack trace is just runtime/init frames.
+var initSentinelErr = errors.New("init sentinel")
+
+func TestHasInitTimeStackOnly(t *testing.T) {
+	t.Run("sentinel created at package init is classified as init-only",
+		func(t *testing.T) {
+			st, ok := initSentinelErr.(stackTracer)
+			require.True(t, ok)
+			assert.True(t, hasInitTimeStackOnly(st))
+		},
+	)
+
+	t.Run("error created inside a function is not classified as init-only",
+		func(t *testing.T) {
+			inFnErr := errors.New("created in a function")
+			st, ok := inFnErr.(stackTracer)
+			require.True(t, ok)
+			assert.False(t, hasInitTimeStackOnly(st))
+		},
+	)
+
+	t.Run("wrap of an init-time sentinel exposes a non-init wrap stack",
+		func(t *testing.T) {
+			wrapped := errors.Wrap(initSentinelErr, "context")
+			st, ok := wrapped.(stackTracer)
+			require.True(t, ok)
+			assert.False(t, hasInitTimeStackOnly(st))
+		},
+	)
+}
+
+func TestIsInitOrRuntimeFrame(t *testing.T) {
+	tests := map[string]bool{
+		"runtime.goexit":                           true,
+		"runtime.main":                             true,
+		"runtime.doInit1":                          true,
+		"main.main":                                true,
+		"github.com/spacelift-io/spcontext.init":   true,
+		"github.com/spacelift-io/spcontext.init.0": true,
+		"github.com/spacelift-io/backend/server/resolvers.(*runResolver).Logs":  false,
+		"github.com/spacelift-io/backend/shared/runlogs.(*Manager).GetLogsPage": false,
+		"main.run": false,
+	}
+
+	for name, expected := range tests {
+		t.Run(name,
+			func(t *testing.T) {
+				require.Equal(t, expected, isInitOrRuntimeFrame(name))
+			},
+		)
+	}
+}

--- a/context.go
+++ b/context.go
@@ -412,8 +412,12 @@ func (ctx *Context) error(fields []interface{}, err error, internal InternalMess
 		var parentErr = err
 		var st stackTracer
 		var errorClass string
-		curSt, ok := parentErr.(stackTracer)
-		if ok {
+
+		// Walk to the deepest stackTracer in the chain so the report points at
+		// the error origin. Skip stacks that contain only runtime frames, those
+		// come from initializing the error itself and carry no value.
+
+		if curSt, ok := parentErr.(stackTracer); ok && !hasInitTimeStackOnly(curSt) {
 			st = curSt
 		}
 
@@ -428,8 +432,12 @@ func (ctx *Context) error(fields []interface{}, err error, internal InternalMess
 			if !ok {
 				continue
 			}
+			if hasInitTimeStackOnly(curSt) {
+				continue
+			}
 			st = curSt
 		}
+
 		if st != nil {
 			curErr = &errorWithStackFrames{err: st}
 			errorClass = reflect.TypeOf(st).String()

--- a/context_test.go
+++ b/context_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/bugsnag/bugsnag-go/v2"
+	bugsnagerrors "github.com/bugsnag/bugsnag-go/v2/errors"
 	"github.com/franela/goblin"
 	"github.com/go-kit/log"
 	. "github.com/onsi/gomega"
@@ -18,6 +19,20 @@ import (
 	"github.com/spacelift-io/spcontext"
 	"github.com/spacelift-io/spcontext/testutils"
 )
+
+// initSentinel is created at package init so it only has runtime stack frames
+var initSentinel = errors.New("init sentinel")
+
+// wrapInitSentinel wraps the sentinel inside this function so the resulting
+// top stack frame is identifiable by name in assertions.
+func wrapInitSentinel(msg string) error {
+	return errors.Wrap(initSentinel, msg)
+}
+
+// doubleWrapInitSentinel wraps wrapInitSentinel once again.
+func doubleWrapInitSentinel(inner, outer string) error {
+	return errors.Wrap(wrapInitSentinel(inner), outer)
+}
 
 func TestContext(t *testing.T) {
 	g := goblin.Goblin(t)
@@ -235,6 +250,85 @@ func TestContext(t *testing.T) {
 
 				g.It("logs message", func() {
 					Expect(logBuffer.String()).To(ContainSubstring(`level=error msg="internal: context canceled"`))
+				})
+			})
+		})
+
+		g.Describe("with package init sentinel in the chain", func() {
+			g.BeforeEach(func() {
+				sut.Notifier = notifier
+				notifier.On("Notify", mock.Anything, mock.Anything).Return(nil)
+			})
+
+			stackFramesErr := func() bugsnagerrors.ErrorWithStackFrames {
+				suite.Require().Len(notifier.Calls, 1)
+				e, ok := notifier.Calls[0].Arguments[0].(bugsnagerrors.ErrorWithStackFrames)
+				suite.Require().True(ok, "notifier should receive a *errorWithStackFrames wrapper")
+				return e
+			}
+
+			bugsnagErrorClass := func() string {
+				suite.Require().Len(notifier.Calls, 1)
+				extras, ok := notifier.Calls[0].Arguments[1].([]any)
+				suite.Require().True(ok)
+				for _, e := range extras {
+					if c, ok := e.(bugsnag.ErrorClass); ok {
+						return c.Name
+					}
+				}
+				return ""
+			}
+
+			g.Describe("just sentinel err, wrapped once", func() {
+				g.JustBeforeEach(func() {
+					_ = sut.DirectError(wrapInitSentinel("contextual"), "outer")
+				})
+
+				g.It("picks the wrap-site stack, not the sentinel init stack", func() {
+					frames := stackFramesErr().StackFrames()
+					suite.Require().NotEmpty(frames)
+
+					// the wrapInitSentinel call is the deepest stack in the chain.
+					suite.Equal("wrapInitSentinel", frames[0].Name,
+						"top frame should be the wrap function, got %q", frames[0].Name)
+				})
+
+				g.It("reports errorClass as the wrap type", func() {
+					suite.Equal("*errors.withStack", bugsnagErrorClass())
+				})
+			})
+
+			g.Describe("just sentinel err, wrapped twice", func() {
+				g.JustBeforeEach(func() {
+					_ = sut.DirectError(doubleWrapInitSentinel("inner", "outer"), "context")
+				})
+
+				g.It("picks the deepest non-init stack (innermost wrap)", func() {
+					frames := stackFramesErr().StackFrames()
+					suite.Require().NotEmpty(frames)
+
+					// doubleWrapInitSentinel calls wrapInitSentinel so the wrapInitSentinel call
+					// is still the deepest stack in the chain.
+					suite.Equal("wrapInitSentinel", frames[0].Name,
+						"top frame should be the innermost wrap function, got %q", frames[0].Name)
+				})
+
+				g.It("reports errorClass as the wrap type", func() {
+					suite.Equal("*errors.withStack", bugsnagErrorClass())
+				})
+			})
+
+			g.Describe("bare sentinel without any wraps", func() {
+				g.JustBeforeEach(func() {
+					_ = sut.DirectError(initSentinel, "context")
+				})
+
+				g.It("falls through to the bare sentinel, no usable wrap to lift the stack from", func() {
+					// if the sentinel error is never wrapped the only stack trace attached to it
+					// is the runtime one, so we'll still have the `*errors.fundamental` error class
+					suite.Require().Len(notifier.Calls, 1)
+					suite.Same(initSentinel, notifier.Calls[0].Arguments[0])
+					suite.Equal("*errors.fundamental", bugsnagErrorClass())
 				})
 			})
 		})
@@ -503,7 +597,7 @@ func TestLogLevel(t *testing.T) {
 	t.Run("Log level is preserved in child contexts", func(t *testing.T) {
 		logBuffer := bytes.NewBuffer(nil)
 		ctx := spcontext.New(log.NewLogfmtLogger(logBuffer), spcontext.WithLogLevel(spcontext.LogLevelWarn))
-		
+
 		childCtx := ctx.With("field", "value")
 		childCtx.Infof("info message")
 		childCtx.Warnf("warn message")


### PR DESCRIPTION
## what

this pull request changes the way error stacks and error classes are determined when reporting an error to bugsnag

## why

`(*Context).error` walks an error chain to find the deepest stack trace so the BugSnag report points at the error origin.

For any chain that bottoms out in a `pkg/errors` sentinel created at package init (`var ErrFoo = errors.New(...)`), the deepest stacktrace is always the sentinel itself which is pretty much useless when it comes to understanding what's causing the error.

The good stack frames created when wrapping sentinel errors were silently overwritten on the last iteration, so reports showed only init frames even when every layer above wrapped properly.

this should help with errors like [this one](https://app.bugsnag.com/spacelift/spacelift-backend-prod/errors/667424e19418d80008185785) and should also improve grouping

### note

besides the unit tests I added it would be nice to test this on a real error so I can verify if my understanding of what's happening is correct, but I haven't managed to do that