### PR TITLE
fix: preserve original error chain so Notifier can assert wrapped errors

### DIFF
--- a/bugsnag.go
+++ b/bugsnag.go
@@ -23,19 +23,25 @@ type stackTracer interface {
 	StackTrace() errors.StackTrace
 }
 
-// errorWithStackFrames satisfies bugsnag.ErrorWithStackFrames for a github.com/pkg/errors error.
-type errorWithStackFrames struct {
-	err stackTracer
+// errorWithGrouping satisfies bugsnag.ErrorWithStackFrames for a github.com/pkg/errors error.
+type errorWithGrouping struct {
+	// original is the error provided by the client, needs to be unwrapped to show the full StackTrace
+	original error
+	// groupingErr must implement stackTracer - we want to see the stack trace in the BugSnag UI
+	groupingErr stackTracer
 }
 
-// Cause returns initial error, provides compatibility for pkg/errors chains.
-func (w *errorWithStackFrames) Cause() error { return w.err }
+func (e *errorWithGrouping) Cause() error { return e.original }
 
-// Unwrap returns initial error, provides compatibility for Go 1.13 error chains.
-func (w *errorWithStackFrames) Unwrap() error { return w.err }
+// Unwrap returns the full original chain so errors.As/Is traversal keeps working
+// (e.g. the notifier's notifyError skip and dberrors.Error detection). Collapsing
+// the chain into a single Bugsnag exception is done downstream, by the notifier,
+// after that inspection.
+func (e *errorWithGrouping) Unwrap() error { return e.original }
 
-func (e *errorWithStackFrames) Error() string {
-	return e.err.Error()
+// Error returns the original error, so we can see the full trace in the Bugsnag UI.
+func (e *errorWithGrouping) Error() string {
+	return e.original.Error()
 }
 
 // hasInitTimeStackOnly reports whether st's stack contains only frames from
@@ -81,8 +87,9 @@ func isInitOrRuntimeFrame(name string) bool {
 	return false
 }
 
-func (e *errorWithStackFrames) StackFrames() []bugsnagerrors.StackFrame {
-	stackTrace := e.err.StackTrace()
+// StackFrames returns the stack frames from the grouping error, which is used by Bugsnag for grouping and reporting.
+func (e *errorWithGrouping) StackFrames() []bugsnagerrors.StackFrame {
+	stackTrace := e.groupingErr.StackTrace()
 
 	out := make([]bugsnagerrors.StackFrame, len(stackTrace))
 	for i, frame := range stackTrace {

--- a/context.go
+++ b/context.go
@@ -388,18 +388,18 @@ func (ctx *Context) error(fields []interface{}, err error, internal InternalMess
 	}
 
 	if ctx.Notifier != nil && !strings.Contains(err.Error(), context.Canceled.Error()) {
-		var parentErr = err
-		var st stackTracer
-		var errorClass string
+		var originalErr = err
+		var deepestGroupingErr stackTracer
 
 		// Walk to the deepest stackTracer in the chain so the report points at
 		// the error origin. Skip stacks that contain only runtime frames, those
 		// come from initializing the error itself and carry no value.
-
-		if curSt, ok := parentErr.(stackTracer); ok && !hasInitTimeStackOnly(curSt) {
-			st = curSt
+		if originalSt, ok := originalErr.(stackTracer); ok && !hasInitTimeStackOnly(originalSt) {
+			deepestGroupingErr = originalSt
 		}
 
+		// find the deepest error implementing StackTrace()
+		// so there's an actionable output in the BugSnag
 		var curErr = err
 		for {
 			unwrapped := errors.Unwrap(curErr)
@@ -414,19 +414,21 @@ func (ctx *Context) error(fields []interface{}, err error, internal InternalMess
 			if hasInitTimeStackOnly(curSt) {
 				continue
 			}
-			st = curSt
+			deepestGroupingErr = curSt
 		}
 
-		if st != nil {
-			curErr = &errorWithStackFrames{err: st}
-			errorClass = reflect.TypeOf(st).String()
+		var errorClass string
+		if deepestGroupingErr != nil {
+			curErr = &errorWithGrouping{groupingErr: deepestGroupingErr, original: originalErr}
+			errorClass = reflect.TypeOf(deepestGroupingErr).String()
 		} else {
-			curErr = parentErr
-			errorClass = reflect.TypeOf(parentErr).String()
+			curErr = originalErr
+			errorClass = reflect.TypeOf(originalErr).String()
 		}
 
-		fieldsMap["original_error"] = parentErr.Error()
+		fieldsMap["original_error"] = originalErr.Error()
 
+		// Bugsnag grouping is done based on the ErrorClase, and errorWithGrouping.StackFrames() (which points to the deepestGroupingErr)
 		if err := ctx.Notifier.Notify(curErr, bugsnag.MetaData{FieldsTab: fieldsMap}, ctx, bugsnag.ErrorClass{Name: errorClass}); err != nil {
 			ctx.Errorf("error notifying the exception tracker: %v", err)
 		}

--- a/context_test.go
+++ b/context_test.go
@@ -76,7 +76,7 @@ func TestContext(t *testing.T) {
 			suite.True(notifier.AssertCalled(
 				t,
 				"Notify",
-				mock.AnythingOfType("*spcontext.errorWithStackFrames"),
+				mock.AnythingOfType("*spcontext.errorWithGrouping"),
 				mock.AnythingOfType("[]interface {}"),
 			))
 		}
@@ -263,7 +263,7 @@ func TestContext(t *testing.T) {
 			stackFramesErr := func() bugsnagerrors.ErrorWithStackFrames {
 				suite.Require().Len(notifier.Calls, 1)
 				e, ok := notifier.Calls[0].Arguments[0].(bugsnagerrors.ErrorWithStackFrames)
-				suite.Require().True(ok, "notifier should receive a *errorWithStackFrames wrapper")
+				suite.Require().True(ok, "notifier should receive a *errorWithGrouping wrapper")
 				return e
 			}
 
@@ -532,4 +532,44 @@ func TestLogLevel(t *testing.T) {
 		assert.NotContains(t, logBuffer.String(), `level=info msg="info message"`)
 		assert.Contains(t, logBuffer.String(), `level=warning msg="warn message"`)
 	})
+}
+
+type suppressNotifyError struct{ error }
+
+func (suppressNotifyError) Notify() bool    { return false }
+func (e suppressNotifyError) Unwrap() error { return e.error }
+
+func TestNotifiedErrorPreservesChainAcrossResend(t *testing.T) {
+	notifier := new(testutils.MockNotifier)
+	notifier.On("Notify", mock.Anything, mock.Anything).Return(nil)
+
+	ctx := spcontext.New(log.NewNopLogger())
+	ctx.Notifier = notifier
+
+	marker := suppressNotifyError{error: errors.Wrap(errors.New("deep"), "down")}
+	err := errors.Wrap(marker, "up")
+
+	// First send: spcontext wraps into errorWithGrouping and notifies once.
+	returned := ctx.InternalError(err, "op failed")
+	notifier.AssertNumberOfCalls(t, "Notify", 1)
+
+	// 1. The marker survives in the error returned to the caller...
+	var inReturned suppressNotifyError
+	require.ErrorAs(t, returned, &inReturned, "marker must survive in the returned error")
+
+	// ...and is reachable in the error actually handed to Notify (the
+	// errorWithGrouping wrapper). This is what the PR fixes: downstream errors.As
+	// (the notifyError skip / dberrors.Error detection) must traverse the full chain.
+	passedToNotify, ok := notifier.Calls[0].Arguments[0].(error)
+	require.True(t, ok)
+	var inNotified suppressNotifyError
+	require.ErrorAs(t, passedToNotify, &inNotified, "marker must be reachable in the error handed to the notifier")
+
+	// 2. Re-sending the already-notified error must NOT notify again.
+	resent := ctx.InternalError(returned, "op failed again")
+	notifier.AssertNumberOfCalls(t, "Notify", 1)
+
+	// 3. The marker is still reachable after the re-send.
+	var afterResend suppressNotifyError
+	require.ErrorAs(t, resent, &afterResend, "marker must still be reachable after re-send")
 }


### PR DESCRIPTION
## Bugsnag grouping context

Bugsnag grouping works according to the `Notify` call in the `context.go`:

```
		if err := ctx.Notifier.Notify(curErr, bugsnag.MetaData{FieldsTab: fieldsMap}, ctx, bugsnag.ErrorClass{Name: errorClass}); err != nil {
			ctx.Errorf("error notifying the exception tracker: %v", err)
		}
```

which is implemented in the [backend@bugsnag_notifier.go](https://github.com/spacelift-io/backend/blob/main/observability/notifier/bugsnag_notifier.go)

The grouping effectively works based on:

1. `errorClass` of the deepest error
2. `errorWithStackFrames.StackFrames()`, which returns the frames from the deepest error implementing `stackTracer` (from `pkg/errors`)

## Why it's not working

When we've added [notifyError](https://github.com/spacelift-io/backend/blob/4e4e80c482c3d2aa3e054172499f2da6eda6e2ce/observability/notifier/bugsnag_notifier.go#L55-L57) to suppress sending new errors to Bugsnag, but this was a no-op. It was because `errorWithStackFrames.Unwrap()` returned the deepest error, effectively ignoring every `notifyError` that could potentially be present in the chain. As a result, all errors were sent to Bugsnag

## What's fixed

- `errorWithStackFrames` renamed to `errorWithGrouping` to reflect the primary responsibility
- `errorWithGrouping.Unwrap()` now returns the original error, which contains the whole chain constructed on the client side.
- `errorWithGrouping.Error()` now returns the whole error string, which contains all wrapped messages (it doesn't affect the grouping in any sense)

## Example

[Error before](https://app.bugsnag.com/spacelift/yantrio-dev-slash-test/errors/6a19456d17b0f7c0947edd94?filters[error.status]=for_review&filters[event.since]=30d&filters[app.release_stage]=production&event_id=6a19456d01814d18c1d00000):
<img width="1521" height="526" alt="obraz" src="https://github.com/user-attachments/assets/deb6700d-1065-4108-9d5b-52a7a38fea94" />

[Error after](https://app.bugsnag.com/spacelift/yantrio-dev-slash-test/errors/6a19456d17b0f7c0947edd94?filters[error.status]=for_review&filters[event.since]=30d&filters[app.release_stage]=production&event_id=6a1984a20174c1e7854a0000) (note that the **STACKTRACE** is much larger, because `Unwrap` allows for the full chain traversal, but it can be reduced on the backend side)
<img width="1530" height="538" alt="obraz" src="https://github.com/user-attachments/assets/92bb81de-0421-4cbe-bb13-e586b442dc13" />

[Error after backend PR](https://app.bugsnag.com/spacelift/yantrio-dev-slash-test/errors/6a19456d17b0f7c0947edd94?filters[error.status]=open&filters[event.since]=30d&event_id=6a1d438b0174a89894e60000) - after https://github.com/spacelift-io/backend/pull/14461 is merged, the error will become much more concise.

## Alternatives

See: https://github.com/spacelift-io/backend/pull/14003#discussion_r3240876989