### PR TITLE
feat: tag analyzed spans with spcontext.analyze

### DIFF
--- a/tracing/datadog/datadog.go
+++ b/tracing/datadog/datadog.go
@@ -36,7 +36,11 @@ func (t *Tracer) OnSpanClose(ctx *spcontext.Context, err error, fields []interfa
 	}
 
 	if analyze || (err != nil && !drop) {
+		// App Analytics (https://docs.datadoghq.com/tracing/legacy_app_analytics) is deprecated.
+		// After its Rust rewrite, the Datadog Lambda Extension stopped tagging spans with analytics_enabled:true.
+		// The recommended way is now to use retention filters; for that, we set spcontext.analyze:true.
 		span.SetTag(ext.AnalyticsEvent, true)
+		span.SetTag("spcontext.analyze", true)
 	}
 
 	// Datadog seems to be OK with duplicate tags but when testing we still want

--- a/tracing/datadog/datadog_test.go
+++ b/tracing/datadog/datadog_test.go
@@ -1,0 +1,69 @@
+package datadog_test
+
+import (
+	"testing"
+
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/mocktracer"
+	"github.com/go-kit/log"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spacelift-io/spcontext"
+	"github.com/spacelift-io/spcontext/tracing/datadog"
+)
+
+func TestOnSpanCloseAnalyze(t *testing.T) {
+	testCases := []struct {
+		name        string
+		err         error
+		opts        []spcontext.SpanCloseOption
+		wantAnalyze bool
+	}{
+		{
+			name:        "span closed with WithAnalyze is analyzed",
+			opts:        []spcontext.SpanCloseOption{spcontext.WithAnalyze()},
+			wantAnalyze: true,
+		},
+		{
+			name:        "errored span is auto-analyzed",
+			err:         errors.New("boom"),
+			wantAnalyze: true,
+		},
+		{
+			name:        "plain span is not analyzed",
+			wantAnalyze: false,
+		},
+		{
+			name:        "dropped errored span is not analyzed",
+			err:         errors.New("boom"),
+			opts:        []spcontext.SpanCloseOption{spcontext.WithDrop()},
+			wantAnalyze: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mt := mocktracer.Start()
+			defer mt.Stop()
+
+			ctx := spcontext.New(log.NewNopLogger(), spcontext.WithTracer(&datadog.Tracer{}))
+			_, span := ctx.StartSpan(spcontext.WithOperation("test.operation"))
+			span.Close(tc.err, tc.opts...)
+
+			finished := mt.FinishedSpans()
+			require.Len(t, finished, 1)
+
+
+			if tc.wantAnalyze {
+				// Setting ext.AnalyticsEvent surfaces as the "_dd1.sr.eausr"
+				// metric on the span - that is what ships on the wire.
+				require.Equal(t, float64(1), finished[0].Tag("_dd1.sr.eausr"))
+				// Boolean tags are stored as strings in span metadata.
+				require.Equal(t, "true", finished[0].Tag("spcontext.analyze"))
+			} else {
+				require.Nil(t, finished[0].Tag("_dd1.sr.eausr"))
+				require.Nil(t, finished[0].Tag("spcontext.analyze"))
+			}
+		})
+	}
+}


### PR DESCRIPTION
App Analytics is deprecated: the legacy Go Lambda Extension tags
analyzed spans with analytics_enabled:true, but Datadog's next-gen
(Rust) Lambda Extension does not, breaking retention filters that
match on that tag.

Setting an explicit tag allows consumers to retain these spans by
setting up retention filters.

[CU-86999790z](https://app.clickup.com/t/86999790z)